### PR TITLE
Add support for listing QueryDescription objects

### DIFF
--- a/sdk/servicebus/azure-servicebus/swagger/servicebus-swagger.json
+++ b/sdk/servicebus/azure-servicebus/swagger/servicebus-swagger.json
@@ -69,7 +69,8 @@
     "AccessRights": {
       "description": "Access rights of the entity",
       "type": "string",
-      "xml":{
+      "xml": {
+        "name": "AccessRights",
         "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
       },
       "enum": [
@@ -82,29 +83,30 @@
       "description": "Authorization rule of an entity",
       "type": "object",
       "xml": {
+        "name": "AuthorizationRule",
         "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
       },
       "properties": {
-        "ClaimType":{
+        "ClaimType": {
           "type": "string",
           "xml": {
             "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
           }
         },
-        "CreatedTime":{
+        "CreatedTime": {
           "type": "string",
           "format": "date-time",
           "xml": {
             "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
           }
         },
-        "KeyName":{
+        "KeyName": {
           "type": "string",
           "xml": {
             "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
           }
         },
-        "ModifiedTime":{
+        "ModifiedTime": {
           "type": "string",
           "format": "date-time",
           "xml": {
@@ -131,7 +133,7 @@
     "CreateQueueBody": {
       "description": "The request body for creating a queue.",
       "type": "object",
-      "xml":{
+      "xml": {
         "name": "entry",
         "namespace": "http://www.w3.org/2005/Atom"
       },
@@ -162,7 +164,7 @@
     "CreateTopicBody": {
       "description": "The request body for creating a topic.",
       "type": "object",
-      "xml":{
+      "xml": {
         "name": "entry",
         "namespace": "http://www.w3.org/2005/Atom"
       },
@@ -193,7 +195,7 @@
     "EntityAvailabilityStatus": {
       "description": "Availibility status of the entity",
       "type": "string",
-      "xml":{
+      "xml": {
         "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
       },
       "enum": [
@@ -207,7 +209,7 @@
     "EntityStatus": {
       "description": "Status of a Service Bus resource",
       "type": "string",
-      "xml":{
+      "xml": {
         "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
       },
       "enum": [
@@ -268,6 +270,7 @@
         }
       },
       "xml": {
+        "name": "CountDetails",
         "namespace": "http://schemas.microsoft.com/netservices/2011/06/servicebus"
       }
     },
@@ -275,6 +278,7 @@
       "description": "Description of a Service Bus queue resource.",
       "type": "object",
       "xml": {
+        "name": "QueueDescription",
         "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
       },
       "properties": {
@@ -286,6 +290,7 @@
           "description": "Authorization rules for resource.",
           "type": "array",
           "xml": {
+            "name": "AuthorizationRules",
             "wrapped": true,
             "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
           },
@@ -420,7 +425,192 @@
         }
       }
     },
-    "QueueRuntimeInfo":{
+    "QueueDescriptionEntry": {
+      "description": "Represents an entry in the feed when querying queues",
+      "type": "object",
+      "properties": {
+        "base": {
+          "description": "Base URL for the query.",
+          "type": "string",
+          "xml": {
+            "name": "base",
+            "attribute": true,
+            "prefix": "xml"
+          }
+        },
+        "id": {
+          "description": "The URL of the GET request",
+          "type": "string"
+        },
+        "title": {
+          "description": "The name of the queue",
+          "type": "string"
+        },
+        "published": {
+          "description": "The timestamp for when this queue was published",
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "description": "The timestamp for when this queue was last updated",
+          "type": "string",
+          "format": "date-time"
+        },
+        "author": {
+          "description": "The author that created this resource",
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "The Service Bus namespace",
+              "type": "string"
+            }
+          }
+        },
+        "link": {
+          "description": "The relative URL link of the GET request",
+          "type": "object",
+          "properties": {
+            "href": {
+              "description": "The URL of the GET request",
+              "type": "string",
+              "xml": {
+                "attribute": true
+              }
+            },
+            "rel": {
+              "description": "What the link href is relative to",
+              "type": "string",
+              "xml": {
+                "attribute": true
+              }
+            }
+          }
+        },
+        "content": {
+          "description": "The QueueDescription",
+          "type": "object",
+          "properties": {
+            "type": {
+              "description": "Type of content in queue response",
+              "type": "string",
+              "xml": {
+                "attribute": true
+              }
+            },
+            "QueueDescription": {
+              "$ref": "#/definitions/QueueDescription"
+            }
+          }
+        }
+      },
+      "xml": {
+        "name": "entry",
+        "namespace": "http://www.w3.org/2005/Atom"
+      }
+    },
+    "QueueDescriptionFeed": {
+      "description": "Response from listing Service Bus queues.",
+      "type": "object",
+      "xml": {
+        "name": "feed",
+        "namespace": "http://www.w3.org/2005/Atom"
+      },
+      "properties": {
+        "id": {
+          "description": "URL of the list queues query.",
+          "type": "string"
+        },
+        "title": {
+          "description": "The entity type for the feed.",
+          "type": "string"
+        },
+        "updated": {
+          "description": "Datetime of the query.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "entry": {
+          "description": "Queue entries.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/QueueDescriptionEntry"
+          }
+        }
+      }
+    },
+    "QueueDescriptionResponse": {
+      "description": "The response from a Queue_Get operation",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "The URL of the GET request",
+          "type": "string"
+        },
+        "title": {
+          "description": "The name of the queue",
+          "type": "string"
+        },
+        "published": {
+          "description": "The timestamp for when this queue was published",
+          "type": "string"
+        },
+        "updated": {
+          "description": "The timestamp for when this queue was last updated",
+          "type": "string"
+        },
+        "author": {
+          "description": "The author that created this resource",
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "The Service Bus namespace",
+              "type": "string"
+            }
+          }
+        },
+        "link": {
+          "description": "The URL link of the GET request",
+          "type": "object",
+          "properties": {
+            "href": {
+              "description": "The URL of the GET request",
+              "type": "string",
+              "xml": {
+                "attribute": true
+              }
+            },
+            "rel": {
+              "description": "What the link href is relative to",
+              "type": "string",
+              "xml": {
+                "attribute": true
+              }
+            }
+          }
+        },
+        "content": {
+          "description": "Contents of a Queue_Get response",
+          "type": "object",
+          "properties": {
+            "type": {
+              "description": "Type of content in queue response",
+              "type": "string",
+              "xml": {
+                "attribute": true
+              }
+            },
+            "QueueDescription": {
+              "$ref": "#/definitions/QueueDescription"
+            }
+          }
+        }
+      },
+      "xml": {
+        "name": "entry",
+        "namespace": "http://www.w3.org/2005/Atom"
+      }
+    },
+    "QueueRuntimeInfo": {
       "description": "Service Bus queue metrics.",
       "type": "object",
       "xml": {
@@ -496,6 +686,7 @@
       "description": "Description of a Service Bus topic resource.",
       "type": "object",
       "xml": {
+        "name": "TopicDescription",
         "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
       },
       "properties": {
@@ -637,7 +828,7 @@
         "responses": {
           "200": {
             "description": "OK",
-            "schema":{
+            "schema": {
               "type": "object"
             }
           },
@@ -708,7 +899,7 @@
         "responses": {
           "200": {
             "description": "OK",
-            "schema":{
+            "schema": {
               "type": "object"
             }
           },
@@ -758,7 +949,7 @@
         "responses": {
           "200": {
             "description": "OK",
-            "schema":{
+            "schema": {
               "type": "object"
             }
           },

--- a/sdk/servicebus/azure-servicebus/swagger/servicebus-swagger.json
+++ b/sdk/servicebus/azure-servicebus/swagger/servicebus-swagger.json
@@ -444,7 +444,7 @@
         },
         "title": {
           "description": "The name of the queue",
-          "type": "string"
+          "$ref": "#/definitions/ResponseTitle"
         },
         "published": {
           "description": "The timestamp for when this queue was published",
@@ -457,34 +457,10 @@
           "format": "date-time"
         },
         "author": {
-          "description": "The author that created this resource",
-          "type": "object",
-          "properties": {
-            "name": {
-              "description": "The Service Bus namespace",
-              "type": "string"
-            }
-          }
+          "$ref": "#/definitions/ResponseAuthor"
         },
         "link": {
-          "description": "The relative URL link of the GET request",
-          "type": "object",
-          "properties": {
-            "href": {
-              "description": "The URL of the GET request",
-              "type": "string",
-              "xml": {
-                "attribute": true
-              }
-            },
-            "rel": {
-              "description": "What the link href is relative to",
-              "type": "string",
-              "xml": {
-                "attribute": true
-              }
-            }
-          }
+          "$ref": "#/definitions/ResponseLink"
         },
         "content": {
           "description": "The QueueDescription",
@@ -559,34 +535,10 @@
           "type": "string"
         },
         "author": {
-          "description": "The author that created this resource",
-          "type": "object",
-          "properties": {
-            "name": {
-              "description": "The Service Bus namespace",
-              "type": "string"
-            }
-          }
+          "$ref": "#/definitions/ResponseAuthor"
         },
         "link": {
-          "description": "The URL link of the GET request",
-          "type": "object",
-          "properties": {
-            "href": {
-              "description": "The URL of the GET request",
-              "type": "string",
-              "xml": {
-                "attribute": true
-              }
-            },
-            "rel": {
-              "description": "What the link href is relative to",
-              "type": "string",
-              "xml": {
-                "attribute": true
-              }
-            }
-          }
+          "$ref": "#/definitions/ResponseLink"
         },
         "content": {
           "description": "Contents of a Queue_Get response",
@@ -665,6 +617,53 @@
             "name": "CountDetails",
             "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
           }
+        }
+      }
+    },
+    "ResponseAuthor": {
+      "description": "The author that created this resource",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The Service Bus namespace",
+          "type": "string"
+        }
+      }
+    },
+    "ResponseLink": {
+      "description": "The URL for the HTTP request",
+      "type": "object",
+      "properties": {
+        "href": {
+          "description": "The URL of the GET request",
+          "type": "string",
+          "xml": {
+            "attribute": true
+          }
+        },
+        "rel": {
+          "description": "What the link href is relative to",
+          "type": "string",
+          "xml": {
+            "attribute": true
+          }
+        }
+      }
+    },
+    "ResponseTitle": {
+      "description": "The title of the response",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Type of value",
+          "type": "string",
+          "xml": {
+            "attribute": true
+          }
+        },
+        "title": {
+          "description": "Contents of the title.",
+          "type": "string"
         }
       }
     },


### PR DESCRIPTION
* Consolidates common swagger objects. These are complex objects because they have both an attribute and a value or multiple values.
  * "author"
  * "link"
  * "title"
* Adds support for deserializing a feed (ie. from list entities).
* Adding localNames back because with only "namespace", it assumes the localName is "null".