### PR TITLE
Add pagination support for feeds.

### DIFF
--- a/sdk/servicebus/azure-servicebus/swagger/servicebus-swagger.json
+++ b/sdk/servicebus/azure-servicebus/swagger/servicebus-swagger.json
@@ -551,6 +551,13 @@
           "type": "string",
           "format": "date-time"
         },
+        "link": {
+          "description": "Links to paginated response.",
+          "type":"array",
+          "items": {
+            "$ref": "#/definitions/ResponseLink"
+          }
+        },
         "entry": {
           "description": "Queue entries.",
           "type": "array",
@@ -636,6 +643,10 @@
             "attribute": true
           }
         }
+      },
+      "xml": {
+        "name": "link",
+        "namespace": "http://www.w3.org/2005/Atom"
       }
     },
     "ResponseTitle": {


### PR DESCRIPTION
When listing entities, if there are more items, the `link` parameter will have multiple links. For example:
```xml
<feed xmlns="http://www.w3.org/2005/Atom">
  <title type="text">Queues</title>
  <id>https://sb-java-conniey-4.servicebus.windows.net/$Resources/queues?api-version=2017-04&amp;enrich=false&amp;$skip=0&amp;$top=5</id>
  <updated>2020-06-05T07:17:21Z</updated>
  <link rel="self" href="https://sb-java.servicebus.windows.net/$Resources/queues?api-version=2017-04&amp;enrich=false&amp;$skip=0&amp;$top=5"/>
  <link rel="next" href="https://sb-java.servicebus.windows.net/$Resources/queues?api-version=2017-04&amp;enrich=false&amp;%24skip=5&amp;%24top=5"/>
  <entry xml:base="https://sb-java.servicebus.windows.net/$Resources/queues?api-version=2017-04&amp;enrich=false&amp;$skip=0&amp;$top=5">
    <id>https://sb-java.servicebus.windows.net/q-0?api-version=2017-04</id>
    <title type="text">q-0</title>
    <published>2020-06-05T07:17:04Z</published>
    <updated>2020-06-05T07:17:04Z</updated>
    <author>
  </entry>
  ....
</feed>
```