### PR TITLE
Update NamespaceProperties support, clean up ResponseTitle. 

### DIFF
--- a/sdk/servicebus/azure-servicebus/swagger/servicebus-swagger.json
+++ b/sdk/servicebus/azure-servicebus/swagger/servicebus-swagger.json
@@ -21,10 +21,11 @@
     "https"
   ],
   "produces": [
-    "application/xml"
+    "application/atom+xml"
   ],
   "consumes": [
-    "application/xml"
+    "application/xml",
+    "application/atom+xml"
   ],
   "tags": [
     {
@@ -373,108 +374,121 @@
         "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
       }
     },
-    "NamespacePropertiesEntry": {
-        "description": "Represents an entry in the feed when querying queues",
-        "type": "object",
-        "properties": {
-          "base": {
-            "description": "Base URL for the query.",
-            "type": "string",
-            "xml": {
-              "name": "base",
-              "attribute": true,
-              "prefix": "xml"
-            }
-          },
-          "id": {
-            "description": "The URL of the GET request",
-            "type": "string",
-            "xml": {
-              "namespace": "http://www.w3.org/2005/Atom"
-            }
-          },
-          "title": {
-            "description": "The name of the queue",
-            "$ref": "#/definitions/ResponseTitle"
-          },
-          "published": {
-            "description": "The timestamp for when this queue was published",
-            "type": "string",
-            "format": "date-time",
-            "xml": {
-              "namespace": "http://www.w3.org/2005/Atom"
-            }
-          },
-          "updated": {
-            "description": "The timestamp for when this queue was last updated",
-            "type": "string",
-            "format": "date-time",
-            "xml": {
-              "namespace": "http://www.w3.org/2005/Atom"
-            }
-          },
-          "author": {
-            "$ref": "#/definitions/ResponseAuthor"
-          },
-          "link": {
-            "$ref": "#/definitions/ResponseLink"
-          },
-          "content": {
-            "description": "The QueueDescription",
-            "type": "object",
-            "xml": {
-              "namespace": "http://www.w3.org/2005/Atom"
-            },
-            "properties": {
-              "type": {
-                "description": "Type of content in queue response",
-                "type": "string",
-                "xml": {
-                  "attribute": true
-                }
-              },
-              "NamespaceInfo": {
-                "description": "The metadata related to a Service Bus namespace.",
-                "type": "object",
-                "properties": {
-                  "CreatedTime": {
-                    "description": "The timestamp for when this namespace was created.",
-                    "type": "string",
-                    "format": "date-time"
-                  },
-                  "MessagingSKU": {
-                    "description": "The SKU for the messaging entity.",
-                    "type": "string"
-                  },
-                  "MessagingUnits": {
-                    "description": "The number of messaging units allocated to the namespace.",
-                    "type": "integer"
-                  },
-                  "ModifiedTime": {
-                    "description": "The timestamp for when this namespace was modified.",
-                    "type": "string",
-                    "format": "date-time"
-                  },
-                  "Name": {
-                    "description": "The name of the Service Bus namespace.",
-                    "type": "string"
-                  },
-                  "NamespaceType": {
-                    "description": "Type of entities present in the namespace.",
-                    "type": "string"
-                  }
-                },
-                "xml": {
-                  "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
-                }
-              }
-            }
+    "NamespaceProperties": {
+      "description": "The metadata related to a Service Bus namespace.",
+      "type": "object",
+      "xml": {
+        "name": "NamespaceInfo",
+        "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+      },
+      "properties": {
+        "Alias": {
+          "description": "Alias for the geo-disaster recovery Service Bus namespace.",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
           }
         },
-        "xml": {
-          "name": "entry",
-          "namespace": "http://www.w3.org/2005/Atom"
+        "CreatedTime": {
+          "description": "The exact time the namespace was created.",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "MessagingSKU": {
+          "description": "The SKU for the messaging entity.",
+          "type": "string",
+          "xml": {
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "MessagingUnits": {
+          "description": "The number of messaging units allocated to the namespace.",
+          "type": "integer",
+          "xml": {
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "ModifiedTime": {
+          "description": "The exact time the namespace was last modified.",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "Name": {
+          "description": "Name of the namespace",
+          "type": "string",
+          "xml": {
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
+        },
+        "NamespaceType": {
+          "description": "Type of entities present in the namespace.",
+          "type": "string",
+          "xml": {
+            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+          }
         }
+      }
+    },
+    "NamespacePropertiesEntry": {
+      "description": "Represents an entry in the feed when querying namespace info",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "The URL of the GET request",
+          "type": "string",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "title": {
+          "description": "The name of the namespace.",
+          "type": "object"
+        },
+        "updated": {
+          "description": "The timestamp for when this namespace was last updated",
+          "type": "string",
+          "format": "date-time",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          }
+        },
+        "author": {
+          "$ref": "#/definitions/ResponseAuthor"
+        },
+        "link": {
+          "$ref": "#/definitions/ResponseLink"
+        },
+        "content": {
+          "description": "Information about the namespace.",
+          "type": "object",
+          "xml": {
+            "namespace": "http://www.w3.org/2005/Atom"
+          },
+          "properties": {
+            "type": {
+              "description": "Type of content in namespace info response",
+              "type": "string",
+              "xml": {
+                "attribute": true
+              }
+            },
+            "NamespaceProperties": {
+              "$ref": "#/definitions/NamespaceProperties"
+            }
+          }
+        }
+      },
+      "xml": {
+        "name": "entry",
+        "namespace": "http://www.w3.org/2005/Atom"
+      }
     },
     "QueueDescription": {
       "description": "Description of a Service Bus queue resource.",
@@ -750,7 +764,7 @@
         },
         "link": {
           "description": "Links to paginated response.",
-          "type":"array",
+          "type": "array",
           "items": {
             "$ref": "#/definitions/ResponseLink"
           }
@@ -767,7 +781,7 @@
     "ResponseAuthor": {
       "description": "The author that created this resource",
       "type": "object",
-      "xml":{
+      "xml": {
         "namespace": "http://www.w3.org/2005/Atom"
       },
       "properties": {
@@ -888,7 +902,7 @@
             "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
           }
         },
-        "FilteringMessagesBeforePublishing":{
+        "FilteringMessagesBeforePublishing": {
           "description": "Filter messages before publishing.",
           "type": "boolean",
           "xml": {
@@ -1101,7 +1115,7 @@
         },
         "link": {
           "description": "Links to paginated response.",
-          "type":"array",
+          "type": "array",
           "items": {
             "$ref": "#/definitions/ResponseLink"
           }
@@ -1322,7 +1336,7 @@
         },
         "link": {
           "description": "Links to paginated response.",
-          "type":"array",
+          "type": "array",
           "items": {
             "$ref": "#/definitions/ResponseLink"
           }
@@ -1337,14 +1351,14 @@
       }
     },
     "RuleFilter": {
-      "type":"object",
+      "type": "object",
       "discriminator": "type",
       "xml": {
         "name": "Filter",
         "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
       },
       "properties": {
-        "type":{
+        "type": {
           "type": "string",
           "xml": {
             "attribute": true,
@@ -1355,7 +1369,7 @@
       }
     },
     "KeyValue": {
-      "type":"object",
+      "type": "object",
       "xml": {
         "name": "KeyValueOfstringanyType",
         "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
@@ -1381,51 +1395,51 @@
           "$ref": "#/definitions/RuleFilter"
         },
         {
-          "type":"object",
+          "type": "object",
           "properties": {
-            "CorrelationId" :{
+            "CorrelationId": {
               "type": "string",
               "xml": {
                 "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
               }
             },
-            "MessageId":{
+            "MessageId": {
               "type": "string",
               "xml": {
                 "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
               }
             },
-            "To" :{
+            "To": {
               "type": "string",
               "xml": {
                 "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
               }
             },
-            "ReplyTo":{
+            "ReplyTo": {
               "type": "string",
               "xml": {
                 "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
               }
             },
-            "Label" :{
+            "Label": {
               "type": "string",
               "xml": {
                 "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
               }
             },
-            "SessionId":{
+            "SessionId": {
               "type": "string",
               "xml": {
                 "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
               }
             },
-            "ReplyToSessionId" :{
+            "ReplyToSessionId": {
               "type": "string",
               "xml": {
                 "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
               }
             },
-            "ContentType":{
+            "ContentType": {
               "type": "string",
               "xml": {
                 "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
@@ -1443,13 +1457,13 @@
         }
       ]
     },
-    "SqlFilter" :{
+    "SqlFilter": {
       "allOf": [
         {
           "$ref": "#/definitions/RuleFilter"
         },
         {
-          "type":"object",
+          "type": "object",
           "properties": {
             "SqlExpression": {
               "type": "string",
@@ -1461,13 +1475,13 @@
         }
       ]
     },
-    "TrueFilter" :{
+    "TrueFilter": {
       "allOf": [
         {
           "$ref": "#/definitions/RuleFilter"
         },
         {
-          "type":"object",
+          "type": "object",
           "properties": {
             "SqlExpression": {
               "type": "string",
@@ -1480,13 +1494,13 @@
         }
       ]
     },
-    "FalseFilter" :{
+    "FalseFilter": {
       "allOf": [
         {
           "$ref": "#/definitions/RuleFilter"
         },
         {
-          "type":"object",
+          "type": "object",
           "properties": {
             "SqlExpression": {
               "type": "string",
@@ -1621,7 +1635,7 @@
         },
         "link": {
           "description": "Links to paginated response.",
-          "type":"array",
+          "type": "array",
           "items": {
             "$ref": "#/definitions/ResponseLink"
           }
@@ -1633,107 +1647,6 @@
             "$ref": "#/definitions/RuleDescriptionEntry"
           }
         }
-      }
-    },
-    "NamespaceProperties": {
-      "description": "Description of a Service Bus Namespace.",
-      "type": "object",
-      "xml": {
-        "name": "NamespaceInfo",
-        "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
-      },
-      "properties": {
-        "CreatedTime": {
-          "description": "The exact time the namespace was created.",
-          "type": "string",
-          "format": "date-time",
-          "xml": {
-            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
-          }
-        },
-        "MessagingSKU": {
-          "description": "",
-          "type": "string",
-          "xml": {
-            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
-          }
-        },
-        "ModifiedTime": {
-          "description": "The exact time the namespace was last modified.",
-          "type": "string",
-          "format": "date-time",
-          "xml": {
-            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
-          }
-        },
-        "Name": {
-          "description": "Name of the namespace",
-          "type": "string",
-          "xml": {
-            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
-          }
-        },
-        "NamespaceType": {
-          "description": "Name of the namespace",
-          "type": "string",
-          "xml": {
-            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
-          }
-        }
-      }
-    },
-    "NamespacePropertiesEntry": {
-      "description": "Represents an entry in the feed when querying namespace info",
-      "type": "object",
-      "properties": {
-        "id": {
-          "description": "The URL of the GET request",
-          "type": "string",
-          "xml": {
-            "namespace": "http://www.w3.org/2005/Atom"
-          }
-        },
-        "title": {
-          "description": "The name of the namespace",
-          "$ref": "#/definitions/ResponseTitle"
-        },
-        "updated": {
-          "description": "The timestamp for when this entry was generated",
-          "type": "string",
-          "format": "date-time",
-          "xml": {
-            "namespace": "http://www.w3.org/2005/Atom"
-          }
-        },
-        "author": {
-          "$ref": "#/definitions/ResponseAuthor"
-        },
-        "link": {
-          "$ref": "#/definitions/ResponseLink"
-        },
-        "content": {
-          "description": "The QueueDescription",
-          "type": "object",
-          "xml": {
-            "namespace": "http://www.w3.org/2005/Atom"
-          },
-          "properties": {
-            "type": {
-              "description": "Type of content in namespace info response",
-              "type": "string",
-              "xml": {
-                "attribute": true
-              }
-            },
-            "NamespaceProperties": {
-              "$ref": "#/definitions/NamespaceProperties"
-            }
-          }
-        }
-      },
-      "xml": {
-        "name": "entry",
-        "namespace": "http://www.w3.org/2005/Atom"
       }
     }
   },
@@ -2037,7 +1950,7 @@
         }
       }
     },
-    "/{topicName}/subscriptions/{subscriptionName}/rules":{
+    "/{topicName}/subscriptions/{subscriptionName}/rules": {
       "parameters": [
         {
           "name": "topicName",
@@ -2095,7 +2008,7 @@
         }
       }
     },
-    "/{topicName}/subscriptions/{subscriptionName}/rules/{ruleName}":{
+    "/{topicName}/subscriptions/{subscriptionName}/rules/{ruleName}": {
       "parameters": [
         {
           "name": "topicName",

--- a/sdk/servicebus/azure-servicebus/swagger/servicebus-swagger.json
+++ b/sdk/servicebus/azure-servicebus/swagger/servicebus-swagger.json
@@ -398,7 +398,6 @@
         "Alias": {
           "description": "Alias for the geo-disaster recovery Service Bus namespace.",
           "type": "string",
-          "format": "date-time",
           "xml": {
             "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
           }
@@ -411,7 +410,7 @@
             "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
           }
         },
-        "MessagingSKU": {
+        "MessagingSku": {
           "$ref": "#/definitions/MessagingSku"
         },
         "MessagingUnits": {
@@ -702,7 +701,7 @@
         },
         "title": {
           "description": "The name of the queue",
-          "$ref": "#/definitions/ResponseTitle"
+          "type": "object"
         },
         "published": {
           "description": "The timestamp for when this queue was published",
@@ -834,14 +833,6 @@
       },
       "xml": {
         "name": "link",
-        "namespace": "http://www.w3.org/2005/Atom"
-      }
-    },
-    "ResponseTitle": {
-      "description": "The title of the response",
-      "type": "object",
-      "xml": {
-        "wrapped": false,
         "namespace": "http://www.w3.org/2005/Atom"
       }
     },
@@ -1044,7 +1035,7 @@
         },
         "title": {
           "description": "The name of the queue",
-          "$ref": "#/definitions/ResponseTitle"
+          "type": "object"
         },
         "published": {
           "description": "The timestamp for when this queue was published",
@@ -1267,8 +1258,8 @@
           }
         },
         "title": {
-          "description": "The name of the queue",
-          "$ref": "#/definitions/ResponseTitle"
+          "description": "The name of the subscription",
+          "type": "object"
         },
         "published": {
           "description": "The timestamp for when this queue was published",
@@ -1567,7 +1558,7 @@
         },
         "title": {
           "description": "The name of the rule",
-          "$ref": "#/definitions/ResponseTitle"
+          "type": "object"
         },
         "published": {
           "description": "The timestamp for when this queue was published",
@@ -2164,7 +2155,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "type": "object"
+              "$ref": "#/definitions/NamespacePropertiesEntry"
             }
           },
           "default": {

--- a/sdk/servicebus/azure-servicebus/swagger/servicebus-swagger.json
+++ b/sdk/servicebus/azure-servicebus/swagger/servicebus-swagger.json
@@ -373,6 +373,109 @@
         "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
       }
     },
+    "NamespacePropertiesEntry": {
+        "description": "Represents an entry in the feed when querying queues",
+        "type": "object",
+        "properties": {
+          "base": {
+            "description": "Base URL for the query.",
+            "type": "string",
+            "xml": {
+              "name": "base",
+              "attribute": true,
+              "prefix": "xml"
+            }
+          },
+          "id": {
+            "description": "The URL of the GET request",
+            "type": "string",
+            "xml": {
+              "namespace": "http://www.w3.org/2005/Atom"
+            }
+          },
+          "title": {
+            "description": "The name of the queue",
+            "$ref": "#/definitions/ResponseTitle"
+          },
+          "published": {
+            "description": "The timestamp for when this queue was published",
+            "type": "string",
+            "format": "date-time",
+            "xml": {
+              "namespace": "http://www.w3.org/2005/Atom"
+            }
+          },
+          "updated": {
+            "description": "The timestamp for when this queue was last updated",
+            "type": "string",
+            "format": "date-time",
+            "xml": {
+              "namespace": "http://www.w3.org/2005/Atom"
+            }
+          },
+          "author": {
+            "$ref": "#/definitions/ResponseAuthor"
+          },
+          "link": {
+            "$ref": "#/definitions/ResponseLink"
+          },
+          "content": {
+            "description": "The QueueDescription",
+            "type": "object",
+            "xml": {
+              "namespace": "http://www.w3.org/2005/Atom"
+            },
+            "properties": {
+              "type": {
+                "description": "Type of content in queue response",
+                "type": "string",
+                "xml": {
+                  "attribute": true
+                }
+              },
+              "NamespaceInfo": {
+                "description": "The metadata related to a Service Bus namespace.",
+                "type": "object",
+                "properties": {
+                  "CreatedTime": {
+                    "description": "The timestamp for when this namespace was created.",
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "MessagingSKU": {
+                    "description": "The SKU for the messaging entity.",
+                    "type": "string"
+                  },
+                  "MessagingUnits": {
+                    "description": "The number of messaging units allocated to the namespace.",
+                    "type": "integer"
+                  },
+                  "ModifiedTime": {
+                    "description": "The timestamp for when this namespace was modified.",
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "Name": {
+                    "description": "The name of the Service Bus namespace.",
+                    "type": "string"
+                  },
+                  "NamespaceType": {
+                    "description": "Type of entities present in the namespace.",
+                    "type": "string"
+                  }
+                },
+                "xml": {
+                  "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+                }
+              }
+            }
+          }
+        },
+        "xml": {
+          "name": "entry",
+          "namespace": "http://www.w3.org/2005/Atom"
+        }
+    },
     "QueueDescription": {
       "description": "Description of a Service Bus queue resource.",
       "type": "object",

--- a/sdk/servicebus/azure-servicebus/swagger/servicebus-swagger.json
+++ b/sdk/servicebus/azure-servicebus/swagger/servicebus-swagger.json
@@ -21,10 +21,10 @@
     "https"
   ],
   "produces": [
+    "application/xml",
     "application/atom+xml"
   ],
   "consumes": [
-    "application/xml",
     "application/atom+xml"
   ],
   "tags": [
@@ -374,6 +374,19 @@
         "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
       }
     },
+    "MessagingSku": {
+      "description": "The SKU for the messaging entity.",
+      "type": "string",
+      "xml": {
+        "name": "MessagingSKU",
+        "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+      },
+      "enum": [
+        "Basic",
+        "Standard",
+        "Premium"
+      ]
+    },
     "NamespaceProperties": {
       "description": "The metadata related to a Service Bus namespace.",
       "type": "object",
@@ -399,11 +412,7 @@
           }
         },
         "MessagingSKU": {
-          "description": "The SKU for the messaging entity.",
-          "type": "string",
-          "xml": {
-            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
-          }
+          "$ref": "#/definitions/MessagingSku"
         },
         "MessagingUnits": {
           "description": "The number of messaging units allocated to the namespace.",
@@ -428,11 +437,7 @@
           }
         },
         "NamespaceType": {
-          "description": "Type of entities present in the namespace.",
-          "type": "string",
-          "xml": {
-            "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
-          }
+          "$ref": "#/definitions/NamespaceType"
         }
       }
     },
@@ -489,6 +494,20 @@
         "name": "entry",
         "namespace": "http://www.w3.org/2005/Atom"
       }
+    },
+    "NamespaceType": {
+      "description": "The type of entities the namespace can contain.",
+      "type": "string",
+      "xml": {
+        "namespace": "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"
+      },
+      "enum": [
+        "Messaging",
+        "NotificationHub",
+        "Mixed",
+        "EventHub",
+        "Relay"
+      ]
     },
     "QueueDescription": {
       "description": "Description of a Service Bus queue resource.",
@@ -820,19 +839,10 @@
     },
     "ResponseTitle": {
       "description": "The title of the response",
-      "type": "string",
+      "type": "object",
       "xml": {
+        "wrapped": false,
         "namespace": "http://www.w3.org/2005/Atom"
-      },
-      "properties": {
-        "type": {
-          "description": "Type of value",
-          "type": "string",
-          "xml": {
-            "attribute": true,
-            "namespace": "http://www.w3.org/2005/Atom"
-          }
-        }
       }
     },
     "ServiceBusManagementError": {


### PR DESCRIPTION
1. Updates produces/consumes -> It is using `application/atom+xml`
    1. Taken from documentation when looking at response/request headers.
1. Fixes NamespacePropertiesEntry and NamespaceProperties
    1. Use MessagingSku and NamespceType enum
    1. Add MessagingUnits and Alias properties
1. Removes ResponseTitle
    1. Replaces instances of "title" (used in entry) with "object"
    1. Java cannot deserialize "title" as a string because it is not a string, it is a complex object.
1. Changes `GET $namespaceInfo` to return `NamespacePropertiesEntry`
    1. It can't return other types like GET entity.